### PR TITLE
add conda environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: codenetwork
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - nodejs=13.9.0=0
+  - pip=19.2.3=py27_0
+  - python=2.7.16=hcb6e200_0
+


### PR DESCRIPTION
This just adds a conda environment description which locks down the node version and ensures python resolves to python2, which is a dependency of the node-gyp `sharpen` package that gatsby uses